### PR TITLE
Add support to optionally specific the paragraph style.

### DIFF
--- a/MGMushParser/MGMushParser.h
+++ b/MGMushParser/MGMushParser.h
@@ -33,9 +33,26 @@ Use `MGMushParser` to create an `NSAttributedString` from an `NSString` with lig
                                             font:(UIFont *)font
                                            color:(UIColor *)color;
 
+/**
+* Takes an `NSString` and returns an appropriately attributed
+* `NSAttributedString`. Additional option to specify the paragraph style.
+*
+* @param markdown An `NSString` containing text marked up with `Mush`
+* @param font The base font to use, from which bold and italic variants will be
+* derived
+* @param color The text colour to use for the resulting attributed string
+* @param style The paragraph style. Set to nil to use the default style.
+*/
++ (NSAttributedString *)attributedStringFromMush:(NSString *)mush
+                                            font:(UIFont *)font
+                                           color:(UIColor *)color
+                                           style:(NSParagraphStyle *)style;
+
 @property (nonatomic, copy) NSString *mush;
 @property (nonatomic, retain) UIFont *baseFont;
 @property (nonatomic, retain) UIColor *baseColor;
+@property (nonatomic, retain) NSParagraphStyle *paragraphStyle;
+
 - (void)parse;
 - (void)strip;
 - (NSAttributedString *)attributedString;

--- a/MGMushParser/MGMushParser.m
+++ b/MGMushParser/MGMushParser.m
@@ -12,10 +12,23 @@
 + (NSAttributedString *)attributedStringFromMush:(NSString *)markdown
                                             font:(UIFont *)font
                                            color:(UIColor *)color {
+    /*Forward the call, just use nil as style to force the default style. Enforce backward compatibility. */
+    return [MGMushParser attributedStringFromMush:markdown
+                                             font:font
+                                            color:color
+                                            style:nil];
+}
+
++ (NSAttributedString *)attributedStringFromMush:(NSString *)markdown
+                                            font:(UIFont *)font
+                                           color:(UIColor *)color
+                                           style:(NSParagraphStyle *)style {
   MGMushParser *parser = [[MGMushParser alloc] init];
   parser.mush = markdown;
   parser.baseColor = color;
   parser.baseFont = font;
+  parser.paragraphStyle = (style !=nil ? style : NSParagraphStyle.defaultParagraphStyle);
+
   if ([UILabel instancesRespondToSelector:@selector(attributedText)]) {
     [parser parse];
   } else {
@@ -30,7 +43,7 @@
   id base = @{
     NSForegroundColorAttributeName:self.baseColor,
     NSFontAttributeName:self.baseFont,
-    NSParagraphStyleAttributeName:NSParagraphStyle.defaultParagraphStyle
+    NSParagraphStyleAttributeName:self.paragraphStyle
   };
   [working addAttributes:base range:(NSRange){0, working.length}];
 


### PR DESCRIPTION
Hey,

I really like your parser. Unfortunately I can not make the text centre in the middle of a label as it always uses the default paragraph style. So I added the option to add a custom paragraph style. Old code should work as before.

Stefan